### PR TITLE
Change array initialisation to be compatible with PHP pre-5.4

### DIFF
--- a/Modules/user/user_model.php
+++ b/Modules/user/user_model.php
@@ -472,7 +472,7 @@ class User
         static $timezones = null;
 
         if ($timezones === null) {
-            $timezones = [];
+            $timezones = array();
             $now = new DateTime();
 
             foreach (DateTimeZone::listIdentifiers() as $timezone) {


### PR DESCRIPTION
The syntax $fred = []; was only introduced in PHP5.4.  Fixes #338.
See http://openenergymonitor.org/emon/node/10687